### PR TITLE
Fix for ActiveRecord >= 3.2.2

### DIFF
--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/arel_tosql.rb
@@ -40,6 +40,7 @@ module Arel
   module Visitors
 
     class MySQL2Spatial < MySQL
+      include Arel::Visitors::BindVisitor
 
       FUNC_MAP = {
         'st_wkttosql' => 'GeomFromText',


### PR DESCRIPTION
In https://github.com/rails/rails/commit/83e42d52e37a33682fcac856330fd5d06e5a529c the interface to vistor.accept has changed. ActiveRecord-Mysql2Spatial-Adapter breaks this. Here's a fix
