### PR TITLE
Code cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Gemfile used for CI testing.
 #
-# -----------------------------------------------------------------------------
 # Copyright 2012 Daniel Azuma
 #
 # All rights reserved.
@@ -30,8 +28,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,8 @@
+=== 0.5.2
+
+* Code cleanup, whitespace, comments
+* Use Ruby 1.9+ syntax for hashes
+
 === 0.5.1 / 2017-07-04
 
 * Move dependency on rgeo-activerecord from unreleased 1.0 branch to 1.3.0 release.

--- a/README.rdoc
+++ b/README.rdoc
@@ -21,13 +21,13 @@ column may need to be NOT NULL.
 
 Examples (require update):
 
-  create_table :my_spatial_table, :options => 'ENGINE=MyISAM' do |t|
-    t.column :latlon, :point, :null => false
+  create_table :my_spatial_table, options: 'ENGINE=MyISAM' do |t|
+    t.column :latlon, :point, null: false
     t.line_string :path
     t.geometry :shape
   end
   change_table :my_spatial_table do |t|
-    t.index :latlon, :spatial => true
+    t.index :latlon, spatial: true
   end
 
 === Spatial Attributes
@@ -80,11 +80,11 @@ Now you can interact with the data using the RGeo types:
 You can create simple queries based on objective equality in the same way
 you would on a scalar column:
 
-  rec = MySpatialTable.where(:latlon => RGeo::Geos.factory.point(-122, 47)).first
+  rec = MySpatialTable.where(latlon: RGeo::Geos.factory.point(-122, 47)).first
 
 You can also use WKT:
 
-  rec = MySpatialTable.where(:latlon => 'POINT(-122 47)').first
+  rec = MySpatialTable.where(latlon: 'POINT(-122 47)').first
 
 The adapter also provides experimental support for more complex queries
 such as radius searches. However, these extensions require Arel 2.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Generic Gem Rakefile
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010-2012 Daniel Azuma
 #
 # All rights reserved.
@@ -30,8 +28,6 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 
 # Load config if present
@@ -93,14 +89,14 @@ internal_ext_info_ = gemspec_.extensions.map do |extconf_path_|
   source_dir_ = ::File.dirname(extconf_path_)
   name_ = ::File.basename(source_dir_)
   {
-    :name => name_,
-    :source_dir => source_dir_,
-    :extconf_path => extconf_path_,
-    :source_glob => "#{source_dir_}/*.{c,h}",
-    :obj_glob => "#{source_dir_}/*.{o,dSYM}",
-    :suffix_makefile_path => "#{source_dir_}/Makefile_#{platform_suffix_}",
-    :built_lib_path => "#{source_dir_}/#{name_}.#{dlext_}",
-    :staged_lib_path => "#{source_dir_}/#{name_}_#{platform_suffix_}.#{dlext_}",
+    name: name_,
+    source_dir: source_dir_,
+    extconf_path: extconf_path_,
+    source_glob: "#{source_dir_}/*.{c,h}",
+    obj_glob: "#{source_dir_}/*.{o,dSYM}",
+    suffix_makefile_path: "#{source_dir_}/Makefile_#{platform_suffix_}",
+    built_lib_path: "#{source_dir_}/#{name_}.#{dlext_}",
+    staged_lib_path: "#{source_dir_}/#{name_}_#{platform_suffix_}.#{dlext_}",
   }
 end
 internal_ext_info_ = [] if platform_ == :jruby
@@ -123,7 +119,7 @@ internal_ext_info_.each do |info_|
   end
 end
 
-task :build_ext => internal_ext_info_.map{ |info_| info_[:staged_lib_path] } do
+task build_ext: internal_ext_info_.map{ |info_| info_[:staged_lib_path] } do
   internal_ext_info_.each do |info_|
     target_prefix_ = target_name_ = nil
     ::Dir.chdir(info_[:source_dir]) do
@@ -161,7 +157,7 @@ end
 
 # RDoc tasks
 
-task :build_rdoc => "#{doc_directory_}/index.html"
+task build_rdoc: "#{doc_directory_}/index.html"
 all_rdoc_files_ = ::Dir.glob("lib/**/*.rb") + gemspec_.extra_rdoc_files
 main_rdoc_file_ = ::RAKEFILE_CONFIG[:main_rdoc_file]
 main_rdoc_file_ = 'README.rdoc' if !main_rdoc_file_ && ::File.readable?('README.rdoc')
@@ -184,19 +180,19 @@ end
 
 task :build_other
 
-task :build_gem => :build_other do
+task build_gem: :build_other do
   ::Gem::Builder.new(gemspec_).build
   mkdir_p(pkg_directory_)
   mv "#{gemspec_.name}-#{gemspec_.version}.gem", "#{pkg_directory_}/"
 end
 
-task :build_release => :build_other do
+task build_release: :build_other do
   ::Gem::Builder.new(release_gemspec_).build
   mkdir_p(pkg_directory_)
   mv "#{release_gemspec_.name}-#{release_gemspec_.version}.gem", "#{pkg_directory_}/"
 end
 
-task :release_gem => :build_release do
+task release_gem: :build_release do
   ::Dir.chdir(pkg_directory_) do
     sh "#{::RbConfig::TOPDIR}/bin/gem push #{release_gemspec_.name}-#{release_gemspec_.version}.gem"
   end
@@ -205,7 +201,7 @@ end
 
 # Unit test task
 
-task :test => [:build_ext, :build_other] do
+task test: [:build_ext, :build_other] do
   $:.unshift(::File.expand_path('lib', ::File.dirname(__FILE__)))
   if ::ENV['TESTCASE']
     test_files_ = ::Dir.glob("test/#{::ENV['TESTCASE']}.rb")
@@ -221,4 +217,4 @@ end
 
 # Default task
 
-task :default => [:clean, :test]
+task default: [:clean, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,6 @@ RAKEFILE_CONFIG = {} unless defined?(::RAKEFILE_CONFIG)
 # Gemspec
 
 require 'rubygems'
-require 'pry'
 gemspec_ = eval(::File.read(::Dir.glob('*.gemspec').first))
 release_gemspec_ = eval(::File.read(::Dir.glob('*.gemspec').first))
 release_gemspec_.version = gemspec_.version.to_s.sub(/\.nonrelease$/, '')

--- a/activerecord-mysql2spatial-adapter.gemspec
+++ b/activerecord-mysql2spatial-adapter.gemspec
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # MySQL2 Spatial ActiveRecord Adapter Gemspec
 #
-# -----------------------------------------------------------------------------
 # Copyright 2011-2012 Daniel Azuma
 #
 # All rights reserved.
@@ -30,7 +28,6 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
 
 ::Gem::Specification.new do |s_|
   s_.name = 'activerecord-mysql2spatial-adapter'

--- a/activerecord-mysql2spatial-adapter.gemspec
+++ b/activerecord-mysql2spatial-adapter.gemspec
@@ -47,7 +47,6 @@
   s_.add_dependency('activerecord', '>= 4.0', '< 4.2')
   s_.add_dependency('rgeo-activerecord', '~> 1.3')
   s_.add_dependency('mysql2', '>= 0.2.13', '< 0.4.0')
-  s_.add_development_dependency('pry')
   s_.add_development_dependency('rake', '>= 0.9.2')
   s_.add_development_dependency('rdoc', '>= 3.12')
 end

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Mysql2Spatial adapter for ActiveRecord
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,25 +28,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 
 require 'rgeo/active_record'
 require 'active_record/connection_adapters/mysql2_adapter'
-
 
 # The activerecord-mysql2spatial-adapter gem installs the *mysql2spatial*
 # connection adapter into ActiveRecord.
 
 module ActiveRecord
 
-
   # ActiveRecord looks for the mysql2spatial_connection factory method in
   # this class.
 
   class Base
-
 
     # Create a mysql2spatial connection adapter.
 
@@ -62,9 +55,7 @@ module ActiveRecord
       ::ActiveRecord::ConnectionAdapters::Mysql2SpatialAdapter::MainAdapter.new(client_, logger, options_, config_)
     end
 
-
   end
-
 
   # All ActiveRecord adapters go in this namespace.
   module ConnectionAdapters
@@ -76,12 +67,8 @@ module ActiveRecord
       ADAPTER_NAME = 'Mysql2Spatial'.freeze
 
     end
-
   end
-
-
 end
-
 
 require 'active_record/connection_adapters/mysql2spatial_adapter/version.rb'
 require 'active_record/connection_adapters/mysql2spatial_adapter/column_methods.rb' # check if this works with Rails < 4.x

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/arel_tosql.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Mysql2Spatial adapter for ActiveRecord
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,15 +28,12 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 
 # :stopdoc:
 
 module Arel
   module Visitors
-
     class MySQL2Spatial < MySQL
 
       if ::Arel::Visitors.const_defined?(:BindVisitor)

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Mysql2Spatial adapter for ActiveRecord
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,24 +28,16 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 
 # :stopdoc:
 
 module ActiveRecord
-
   module ConnectionAdapters
-
     module Mysql2SpatialAdapter
-
-
       class MainAdapter < ConnectionAdapters::Mysql2Adapter
 
-
         NATIVE_DATABASE_TYPES = Mysql2Adapter::NATIVE_DATABASE_TYPES.merge(spatial: { name: 'geometry' })
-
 
         def initialize(*args_)
           super
@@ -57,35 +47,29 @@ module ActiveRecord
           end
         end
 
-
         def set_rgeo_factory_settings(factory_settings_)
           @rgeo_factory_settings = factory_settings_
         end
-
 
         def adapter_name
           Mysql2SpatialAdapter::ADAPTER_NAME
         end
 
-
         def spatial_column_constructor(name_)
           ::RGeo::ActiveRecord::DEFAULT_SPATIAL_COLUMN_CONSTRUCTORS[name_]
         end
-
 
         def native_database_types
           NATIVE_DATABASE_TYPES
         end
 
-
         def quote(value_, column_=nil)
           if ::RGeo::Feature::Geometry.check_type(value_)
-            "GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(:hex_format => true).generate(value_)},#{value_.srid})"
+            "GeomFromWKB(0x#{::RGeo::WKRep::WKBGenerator.new(hex_format: true).generate(value_)},#{value_.srid})"
           else
             super
           end
         end
-
 
         def type_to_sql(type_, limit_=nil, precision_=nil, scale_=nil)
           if (info_ = spatial_column_constructor(type_.to_sym))
@@ -96,10 +80,9 @@ module ActiveRecord
           super(type_, limit_, precision_, scale_)
         end
 
-
         def add_index(table_name_, column_name_, options_={})
           if options_[:spatial]
-            index_name_ = index_name(table_name_, :column => Array(column_name_))
+            index_name_ = index_name(table_name_, column: Array(column_name_))
             if ::Hash === options_
               index_name_ = options_[:name] || index_name_
             end
@@ -109,11 +92,10 @@ module ActiveRecord
           end
         end
 
-
         def columns(table_name_, name_=nil)
           result_ = execute("SHOW FIELDS FROM #{quote_table_name(table_name_)}", :skip_logging)
           columns_ = []
-          result_.each(:symbolize_keys => true, :as => :hash) do |field_|
+          result_.each(symbolize_keys: true, as: :hash) do |field_|
             columns_ << SpatialColumn.new(@rgeo_factory_settings, table_name_.to_s,
               field_[:Field], field_[:Default], field_[:Type], field_[:Null] == "YES")
           end
@@ -125,7 +107,7 @@ module ActiveRecord
           indexes_ = []
           current_index_ = nil
           result_ = execute("SHOW KEYS FROM #{quote_table_name(table_name_)}", name_)
-          result_.each(:symbolize_keys => true, :as => :hash) do |row_|
+          result_.each(symbolize_keys: true, as: :hash) do |row_|
             if current_index_ != row_[:Key_name]
               next if row_[:Key_name] == 'PRIMARY' # skip the primary key
               current_index_ = row_[:Key_name]
@@ -146,15 +128,9 @@ module ActiveRecord
           end
           indexes_
         end
-
-
       end
-
-
     end
-
   end
-
 end
 
 # :startdoc:

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/spatial_column.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/spatial_column.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Mysql2Spatial adapter for ActiveRecord
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,18 +28,13 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 
 # :stopdoc:
 
 module ActiveRecord
-
   module ConnectionAdapters
-
     module Mysql2SpatialAdapter
-
 
       # ActiveRecord 3.2 uses ConnectionAdapters::Mysql2Adapter::Column
       # whereas 3.0 and 3.1 use ConnectionAdapters::Mysql2Column
@@ -50,9 +43,7 @@ module ActiveRecord
 
       class SpatialColumn < column_base_class_
 
-
         FACTORY_SETTINGS_CACHE = {}
-
 
         def initialize(factory_settings_, table_name_, name_, default_, sql_type_=nil, null_=true)
           @factory_settings = factory_settings_
@@ -65,19 +56,15 @@ module ActiveRecord
           FACTORY_SETTINGS_CACHE[factory_settings_.object_id] = factory_settings_
         end
 
-
         attr_reader :geometric_type
-
 
         def spatial?
           type == :spatial
         end
 
-
         def klass
           type == :spatial ? ::RGeo::Feature::Geometry : super
         end
-
 
         def type_cast(value_)
           if type == :spatial
@@ -86,7 +73,6 @@ module ActiveRecord
             super
           end
         end
-
 
         def type_cast_code(var_name_)
           if type == :spatial
@@ -98,7 +84,6 @@ module ActiveRecord
           end
         end
 
-
         private
 
         def simplified_type(sql_type_)
@@ -109,24 +94,24 @@ module ActiveRecord
         def self.convert_to_geometry(input_, factory_settings_, table_name_, column_)
           case input_
           when ::RGeo::Feature::Geometry
-            factory_ = factory_settings_.get_column_factory(table_name_, column_, :srid => input_.srid)
+            factory_ = factory_settings_.get_column_factory(table_name_, column_, srid: input_.srid)
             ::RGeo::Feature.cast(input_, factory_) rescue nil
           when ::String
             marker_ = input_[4,1]
             if marker_ == "\x00" || marker_ == "\x01"
               factory_ = factory_settings_.get_column_factory(table_name_, column_,
-                :srid => input_[0,4].unpack(marker_ == "\x01" ? 'V' : 'N').first)
+                srid: input_[0, 4].unpack(marker_ == "\x01" ? 'V' : 'N').first)
               ::RGeo::WKRep::WKBParser.new(factory_).parse(input_[4..-1]) rescue nil
             elsif input_[0,10] =~ /[0-9a-fA-F]{8}0[01]/
               srid_ = input_[0,8].to_i(16)
               if input[9,1] == '1'
                 srid_ = [srid_].pack('V').unpack('N').first
               end
-              factory_ = factory_settings_.get_column_factory(table_name_, column_, :srid => srid_)
+              factory_ = factory_settings_.get_column_factory(table_name_, column_, srid: srid_)
               ::RGeo::WKRep::WKBParser.new(factory_).parse(input_[8..-1]) rescue nil
             else
               factory_ = factory_settings_.get_column_factory(table_name_, column_)
-              ::RGeo::WKRep::WKTParser.new(factory_, :support_ewkt => true).parse(input_) rescue nil
+              ::RGeo::WKRep::WKTParser.new(factory_, support_ewkt: true).parse(input_) rescue nil
             end
           else
             nil

--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/version.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/version.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Mysql2Spatial adapter for ActiveRecord
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,8 +28,6 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 
 begin
@@ -39,13 +35,9 @@ begin
 rescue ::LoadError
 end
 
-
 module ActiveRecord
-
   module ConnectionAdapters
-
     module Mysql2SpatialAdapter
-
 
       # Current version of Mysql2SpatialAdapter as a frozen string
       VERSION_STRING = ::File.read(::File.dirname(__FILE__)+'/../../../../Version').strip.freeze
@@ -54,9 +46,6 @@ module ActiveRecord
       # Versionomy gem is available; otherwise equal to VERSION_STRING.
       VERSION = defined?(::Versionomy) ? ::Versionomy.parse(VERSION_STRING) : VERSION_STRING
 
-
     end
-
   end
-
 end

--- a/rakefile_config.rb
+++ b/rakefile_config.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # MySQL2 Spatial Adapter Rakefile configuration
 #
-# -----------------------------------------------------------------------------
 # Copyright 2012 Daniel Azuma
 #
 # All rights reserved.
@@ -30,9 +28,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 RAKEFILE_CONFIG = {
-  :product_visible_name => 'MySQL2 Spatial ActiveRecord Adapter',
+  product_visible_name: 'MySQL2 Spatial ActiveRecord Adapter',
 }

--- a/test/tc_basic.rb
+++ b/test/tc_basic.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Tests for the Mysql2Spatial ActiveRecord adapter
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,26 +28,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 require 'minitest/autorun'
 require 'rgeo/active_record/adapter_test_helper'
-
 
 module RGeo
   module ActiveRecord  # :nodoc:
     module Mysql2SpatialAdapter  # :nodoc:
       module Tests  # :nodoc:
-
         class TestBasic < ::Minitest::Test  # :nodoc:
 
           DATABASE_CONFIG_PATH = ::File.dirname(__FILE__)+'/database.yml'
           include RGeo::ActiveRecord::AdapterTestHelper
 
           define_test_methods do
-
-
             def populate_ar_class(content_)
               klass_ = create_ar_class
               case content_
@@ -61,11 +53,9 @@ module RGeo
               klass_
             end
 
-
             def test_version
               refute_nil(::ActiveRecord::ConnectionAdapters::Mysql2SpatialAdapter::VERSION)
             end
-
 
             def test_create_simple_geometry
               klass_ = create_ar_class
@@ -76,7 +66,6 @@ module RGeo
               assert(klass_.cached_attributes.include?('latlon'))
             end
 
-
             def test_create_point_geometry
               klass_ = create_ar_class
               klass_.connection.create_table(:spatial_test) do |t_|
@@ -86,18 +75,16 @@ module RGeo
               assert(klass_.cached_attributes.include?('latlon'))
             end
 
-
             def test_create_geometry_with_index
               klass_ = create_ar_class
-              klass_.connection.create_table(:spatial_test, :options => 'ENGINE=MyISAM') do |t_|
-                t_.column 'latlon', :geometry, :null => false
+              klass_.connection.create_table(:spatial_test, options: 'ENGINE=MyISAM') do |t_|
+                t_.column 'latlon', :geometry, null: false
               end
               klass_.connection.change_table(:spatial_test) do |t_|
-                t_.index([:latlon], :spatial => true)
+                t_.index([:latlon], spatial: true)
               end
               assert(klass_.connection.indexes(:spatial_test).last.spatial)
             end
-
 
             def test_set_and_get_point
               klass_ = populate_ar_class(:latlon_point)
@@ -108,7 +95,6 @@ module RGeo
               assert_equal(3785, obj_.latlon.srid)
             end
 
-
             def test_set_and_get_point_from_wkt
               klass_ = populate_ar_class(:latlon_point)
               obj_ = klass_.new
@@ -117,7 +103,6 @@ module RGeo
               assert_equal(@factory.point(1, 2), obj_.latlon)
               assert_equal(1000, obj_.latlon.srid)
             end
-
 
             def test_save_and_load_point
               klass_ = populate_ar_class(:latlon_point)
@@ -130,7 +115,6 @@ module RGeo
               assert_equal(3785, obj2_.latlon.srid)
             end
 
-
             def test_save_and_load_point_from_wkt
               klass_ = populate_ar_class(:latlon_point)
               obj_ = klass_.new
@@ -142,16 +126,15 @@ module RGeo
               assert_equal(1000, obj2_.latlon.srid)
             end
 
-
             def test_readme_example
               klass_ = create_ar_class
-              klass_.connection.create_table(:spatial_test, :options => 'ENGINE=MyISAM') do |t_|
-                t_.column(:latlon, :point, :null => false)
+              klass_.connection.create_table(:spatial_test, options: 'ENGINE=MyISAM') do |t_|
+                t_.column(:latlon, :point, null: false)
                 t_.line_string(:path)
                 t_.geometry(:shape)
               end
               klass_.connection.change_table(:spatial_test) do |t_|
-                t_.index(:latlon, :spatial => true)
+                t_.index(:latlon, spatial: true)
               end
               klass_.class_eval do
                 self.rgeo_factory_generator = ::RGeo::Geos.method(:factory)
@@ -165,7 +148,6 @@ module RGeo
               assert_equal(true, ::RGeo::Geos.is_geos?(rec_.shape))
             end
 
-
             def test_create_simple_geometry_using_shortcut
               klass_ = create_ar_class
               klass_.connection.create_table(:spatial_test) do |t_|
@@ -174,7 +156,6 @@ module RGeo
               assert_equal(::RGeo::Feature::Geometry, klass_.columns.last.geometric_type)
               assert(klass_.cached_attributes.include?('latlon'))
             end
-
 
             def test_create_point_geometry_using_shortcut
               klass_ = create_ar_class
@@ -185,21 +166,18 @@ module RGeo
               assert(klass_.cached_attributes.include?('latlon'))
             end
 
-
             def test_create_geometry_using_limit
               klass_ = create_ar_class
               klass_.connection.create_table(:spatial_test) do |t_|
-                t_.spatial 'geom', :limit => {:type => :line_string}
+                t_.spatial 'geom', limit: { type: :line_string }
               end
               assert_equal(::RGeo::Feature::LineString, klass_.columns.last.geometric_type)
               assert(klass_.cached_attributes.include?('geom'))
             end
 
-
           end
 
         end
-
       end
     end
   end

--- a/test/tc_spatial_queries.rb
+++ b/test/tc_spatial_queries.rb
@@ -1,8 +1,6 @@
-# -----------------------------------------------------------------------------
 #
 # Tests for the Mysql2Spatial ActiveRecord adapter
 #
-# -----------------------------------------------------------------------------
 # Copyright 2010 Daniel Azuma
 #
 # All rights reserved.
@@ -30,25 +28,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# -----------------------------------------------------------------------------
-;
 
 require 'minitest/autorun'
 require 'rgeo/active_record/adapter_test_helper'
-
 
 module RGeo
   module ActiveRecord  # :nodoc:
     module Mysql2SpatialAdapter  # :nodoc:
       module Tests  # :nodoc:
-
         class TestSpatialQueries < ::Minitest::Test  # :nodoc:
 
           DATABASE_CONFIG_PATH = ::File.dirname(__FILE__)+'/database.yml'
           include RGeo::ActiveRecord::AdapterTestHelper
 
           define_test_methods do
-
 
             def populate_ar_class(content_)
               klass_ = create_ar_class
@@ -65,19 +58,17 @@ module RGeo
               klass_
             end
 
-
             def test_query_point
               klass_ = populate_ar_class(:latlon_point)
               obj_ = klass_.new
               obj_.latlon = @factory.point(1, 2)
               obj_.save!
               id_ = obj_.id
-              obj2_ = klass_.where(:latlon => @factory.point(1, 2)).first
+              obj2_ = klass_.where(latlon: @factory.point(1, 2)).first
               assert_equal(id_, obj2_.id)
-              obj3_ = klass_.where(:latlon => @factory.point(2, 2)).first
+              obj3_ = klass_.where(latlon: @factory.point(2, 2)).first
               assert_nil(obj3_)
             end
-
 
             def _test_query_point_wkt
               klass_ = populate_ar_class(:latlon_point)
@@ -85,15 +76,13 @@ module RGeo
               obj_.latlon = @factory.point(1, 2)
               obj_.save!
               id_ = obj_.id
-              obj2_ = klass_.where(:latlon => 'POINT(1 2)').first
+              obj2_ = klass_.where(latlon: 'POINT(1 2)').first
               assert_equal(id_, obj2_.id)
-              obj3_ = klass_.where(:latlon => 'POINT(2 2)').first
+              obj3_ = klass_.where(latlon: 'POINT(2 2)').first
               assert_nil(obj3_)
             end
 
-
             if ::RGeo::ActiveRecord.spatial_expressions_supported?
-
 
               def test_query_st_length
                 klass_ = populate_ar_class(:path_linestring)
@@ -107,18 +96,13 @@ module RGeo
                 assert_nil(obj3_)
               end
 
-
             else
-
               puts "WARNING: The current Arel does not support named functions. Spatial expression tests skipped."
-
             end
-
 
           end
 
         end
-
       end
     end
   end


### PR DESCRIPTION
- Use Ruby 1.9 hash syntax where possible
- Remove --- and ; from file headers
- Remove excess whitespace
- Use spaces inside {} around one-line blocks and hashes

I
- cherry-picked https://github.com/rgeo/activerecord-mysql2spatial-adapter/tree/code_cleanup onto current master
- fixed a few more =>
- fixed spacing in one-line blocks and hashes
- changed new gem version from 0.6.0 to 0.5.2, since the only user-visible change is the removal of => from the README

Lots more things could be cleaned up, but it would be nice to merge this change and move on.